### PR TITLE
Update assignments.md

### DIFF
--- a/assignments.md
+++ b/assignments.md
@@ -226,7 +226,7 @@ You can choose which assignments you want to do based on your skill level. Try t
       - make `<div id="results">` element to the HTML document where you append the `<article>` elements.  
    - clear the old results with `innerHTML = ''` before you append the new results.
 4. Develop the app even further. Optional chaining is not the best way to handle missing image. Use [ternary operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) or if/else to add a default image if TV-show is missing image property. (**2p**)
-   - Use `https://via.placeholder.com/210x295?text=Not%20Found` as the default image.
+   - Use `https://placehold.co/210x295?text=Not%20Found` as the default image.
 5. Make an app that retrieves a random Chuck Norris joke and displays it in the console. (**2p**)
     - API to use: [chucknorris.io](https://api.chucknorris.io/)
     - Send a request to `https://api.chucknorris.io/jokes/random` and print only the joke to the console (that would be the 'value' property)


### PR DESCRIPTION
This pull request includes a minor update to the `assignments.md` file. The change updates the placeholder image URL for missing TV-show images to a new service.

* Updated the default image URL for missing TV-show images to use `https://placehold.co/210x295?text=Not%20Found` instead of `https://via.placeholder.com/210x295?text=Not%20Found`. (`assignments.md`, [assignments.mdL229-R229](diffhunk://#diff-68b69182e58884b18395986733bafa6675b67dd1ce7cfcd478f4fef5822016fdL229-R229))

## Summary by Sourcery

Documentation:
- Updated the default placeholder image URL from 'via.placeholder.com' to 'placehold.co' in the assignments markdown file